### PR TITLE
Add modern cmake style CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(
   Qt5
   COMPONENTS Core Gui
   REQUIRED)
-find_package(OpenCV REQUIRED)
+find_package(OpenCV 3.4 REQUIRED)
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Gui ${OpenCV_LIBS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(QtOpenCV)
+
+add_library(${PROJECT_NAME} cvmatandqimage.cpp)
+
+find_package(
+  Qt5
+  COMPONENTS Core Gui
+  REQUIRED)
+find_package(OpenCV REQUIRED)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Core Qt5::Gui ${OpenCV_LIBS})
+
+include(GNUInstallDirs)
+target_include_directories(
+  ${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+                         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/cvmatandqimage.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib/static)
+install(EXPORT ${PROJECT_NAME}Targets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+install(FILES ${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}Config.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/cmake/QtOpenCVConfig.cmake
+++ b/cmake/QtOpenCVConfig.cmake
@@ -1,0 +1,6 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Qt5 COMPONENTS Core Gui)
+find_dependency(OpenCV)
+
+include(${CMAKE_CURRENT_LIST_DIR}/QtOpenCVTargets.cmake)


### PR DESCRIPTION
Add modern cmake style CMakeLists.txt so that other modules can refer to it by simply using `add_subdirectory` or `find_package`.

e.g.

```cmake
add_subdirectory(third_party/QtOpenCV)
target_link_libraries(${PROJECT_NAME} PRIVATE QtOpenCV)
```
or

```cmake
find_package(QtOpenCV REQUIRED)
target_link_libraries(${PROJECT_NAME} PRIVATE QtOpenCV)
```